### PR TITLE
Disable publish of the wasmi CLI in this repo

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/paritytech/wasmi"
 documentation = "https://paritytech.github.io/wasmi/"
 description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
+publish = false
 
 [dependencies]
 clap = { version = "3.2", features = ["derive"] }


### PR DESCRIPTION
### What
Disable publish of the wasmi CLI in this repo.

### Why
As part of the soroban-wasmi releases we don't want to republish the CLI.