### PR TITLE
Set base branch in bump versions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,3 +13,4 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-bump-version.yml@main
     with:
       version: ${{ inputs.version }}
+      base: soroban-wasmi-v0.16


### PR DESCRIPTION
### What
Set base branch in bump versions.

### Why
Because the base branch is not `main`.