### PR TITLE
Add a path to the benches bench

### DIFF
--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -32,4 +32,5 @@ std = [
 
 [[bench]]
 name = "benches"
+path = "benches/benches.rs"
 harness = false


### PR DESCRIPTION
### What
Add a path to the benches bench in Cargo.toml.

### Why
The benches directory is excluded during publishing due to the `exclude` option in the Cargo.toml, but this causes validation of the toml file to fail because the `[[bench]]` table with `name = "benches"` no longer finds a directory to match.

This is a problem with the wasmi toml files upstream too.

The solution according to the forum thread below is to explicitly specify the path to the entry point of the bench. Once cargo is told the explicit path it won't try and find the path itself and it won't validate the location.
https://users.rust-lang.org/t/cargo-publish-with-excluded-benchmark-fails-validation/53444