### PR TITLE
Optimize metering flushes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,4 @@ jobs:
     with:
       runs-on: ${{ matrix.sys.os }}
       cargo-hack-feature-options: ${{ matrix.sys.cargo-hack-feature-options }}
-      cargo-package-options: --target ${{ matrix.sys.target }}
+      target: ${{ matrix.sys.target }}

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -101,17 +101,16 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 Instr::GetLocal { local_depth } => { exec_ctx.visit_get_local(*local_depth)?; }
                 Instr::SetLocal { local_depth } => { exec_ctx.visit_set_local(*local_depth)?; }
                 Instr::TeeLocal { local_depth } => { exec_ctx.visit_tee_local(*local_depth)?; }
-                Instr::Br(target) => { step_meter.flush()?; exec_ctx.visit_br(*target)?; }
-                Instr::BrIfEqz(target) => { step_meter.flush()?; exec_ctx.visit_br_if_eqz(*target)?; }
-                Instr::BrIfNez(target) => { step_meter.flush()?; exec_ctx.visit_br_if_nez(*target)?; }
+                Instr::Br(target) => { exec_ctx.visit_br(*target)?; }
+                Instr::BrIfEqz(target) => { exec_ctx.visit_br_if_eqz(*target)?; }
+                Instr::BrIfNez(target) => { exec_ctx.visit_br_if_nez(*target)?; }
                 Instr::ReturnIfNez(drop_keep)  => {
-                    step_meter.flush()?;
                     if let MaybeReturn::Return = exec_ctx.visit_return_if_nez(*drop_keep)? {
+                        step_meter.flush()?;
                         return Ok(CallOutcome::Return)
                     }
                 }
                 Instr::BrTable { len_targets } => {
-                    step_meter.flush()?;
                     exec_ctx.visit_br_table(*len_targets)?;
                 }
                 Instr::Unreachable => { step_meter.flush()?; exec_ctx.visit_unreachable()?; }


### PR DESCRIPTION
@graydon first experimented and identified this issue. I'm making the code change and presenting findings. 

**What** 
Step meter's `flush` is implicitly called by the meter itself when the instruction count reaches the threshold (256). 
This PR ensures: only explicitly call `flush` if we are returning from WASM to host, either 1. the entire code execution finishes and returns 2. branches to function call which may return to host. 

**Why**
Previously, we were flushing in every `br` call that are still in the same wasm execution context. This results in premature meter charging (where the threshold is not respected), and slower execution. 

I ran the [fannkuch](https://github.com/stellar/rs-soroban-env/tree/main/soroban-test-wasms/wasm-workspace/fannkuch) contract (around 38M steps, where each step is an interpreter loop) and did a comparison and observed significant improvements (~33%) in performance.
|| Before      | After |
| -----------|----------- | ----------- |
| No. flushes |   4.31M    | 140k   |
| Ave. steps per flush | 8   | 256        |
|Exec. time| 128ms | 85ms |
|Exec.time (nsecs)/step| 3 | 2 | 

